### PR TITLE
단어 저장, 타임존, 삭제 확인

### DIFF
--- a/components/common/CategoryChipGroup.tsx
+++ b/components/common/CategoryChipGroup.tsx
@@ -8,14 +8,14 @@ export const CategoryChipGroup = ({
   selectedCategory,
   onSelectCategory,
 }: CategoryChipGroupProps) => (
-  <View className="h-16 items-center"> 
+  <View className="h-16 items-center">
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{
         alignItems: 'center',
         paddingHorizontal: 16,
-        gap: 8, // gap-2에 해당
+        gap: 8,
       }}
     >
       {categories.map((category) => (

--- a/components/screens/Dictionary/WordDefinition.tsx
+++ b/components/screens/Dictionary/WordDefinition.tsx
@@ -2,7 +2,7 @@ import { ScrollView, Text, View } from 'react-native';
 
 interface WordDefinitionProps {
   word: string
-  definitions: string[]  // 여러 개 뜻
+  definitions: string[]
   showWord?: boolean
 }
 

--- a/components/screens/Dictionary/index.ts
+++ b/components/screens/Dictionary/index.ts
@@ -1,3 +1,4 @@
 export { DictionaryModal } from './DictionaryModal'
 export { DictionarySearchBar } from './DictionarySearchBar'
 export { WordDefinition } from './WordDefinition'
+

--- a/components/screens/Dictionary/index.ts
+++ b/components/screens/Dictionary/index.ts
@@ -1,3 +1,3 @@
 export { DictionaryModal } from './DictionaryModal'
 export { DictionarySearchBar } from './DictionarySearchBar'
-
+export { WordDefinition } from './WordDefinition'

--- a/components/screens/Discussion/DiscussionNewsCard.tsx
+++ b/components/screens/Discussion/DiscussionNewsCard.tsx
@@ -8,10 +8,17 @@ export function DiscussionNewsCard({ news, onPress }: DiscussionNewsCardProps) {
   return (
     <TouchableOpacity
       onPress={onPress}
-      className="bg-white rounded-2xl mx-4 mb-3 shadow-lg"
+      className="bg-white rounded-2xl mx-4 mb-3"
+      style={{
+        shadowColor: "#000",
+        shadowOffset: { width: 2, height: 2 },
+        shadowOpacity: 0.15,
+        shadowRadius: 6,
+        elevation: 4,
+      }}
       activeOpacity={0.7}
     >
-      <View className="p-4 rounded-xl overflow-hidden">
+      <View className="pt-4 px-4 pb-1 rounded-xl overflow-hidden">
         <View className="flex-row gap-3">
           {/* 이미지 */}
           {imageError ? (

--- a/components/screens/Discussion/DiscussionNewsList.tsx
+++ b/components/screens/Discussion/DiscussionNewsList.tsx
@@ -64,7 +64,11 @@ export function DiscussionNewsList({
       </View>
 
       {/* 뉴스 리스트 */}
-      <ScrollView className="flex-1">
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 20 }}
+      >
         {news.length === 0 ? (
           <View className="flex-1 items-center justify-center py-20">
             <Text className="text-gray-400 text-base">본 뉴스가 없습니다</Text>

--- a/components/screens/NewsPlayer/NewsPlayerScreen.tsx
+++ b/components/screens/NewsPlayer/NewsPlayerScreen.tsx
@@ -28,11 +28,30 @@ export const NewsPlayerScreen = ({ articleId }: NewsPlayerScreenProps) => {
   const [error, setError] = useState<string | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
 
+  // 최근 본 기사 목록
+  const [recentArticles, setRecentArticles] = useState<number[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+
   // 모달 상태 추가
   const [showCarModeErrorModal, setShowCarModeErrorModal] = useState(false);
   const [showSaveConfirmModal, setShowSaveConfirmModal] = useState(false);
   const [showSaveResultModal, setShowSaveResultModal] = useState(false);
   const [saveResultMessage, setSaveResultMessage] = useState('');
+
+  // 최근 본 기사 목록 가져오기
+  const fetchRecentArticles = useCallback(async () => {
+    try {
+      const response = await newsService.getRecentArticles('RECENT');
+      const articleIds = response.map(article => article.id);
+      setRecentArticles(articleIds);
+
+      // 현재 기사의 인덱스 찾기
+      const index = articleIds.findIndex(id => id === parseInt(articleId));
+      setCurrentIndex(index);
+    } catch (err) {
+      console.error('최근 본 기사 목록 로드 실패:', err);
+    }
+  }, [articleId]);
 
   const fetchNewsData = useCallback(async () => {
     try {
@@ -49,7 +68,8 @@ export const NewsPlayerScreen = ({ articleId }: NewsPlayerScreenProps) => {
 
   useEffect(() => {
     fetchNewsData();
-  }, [fetchNewsData]);
+    fetchRecentArticles();
+  }, [fetchNewsData, fetchRecentArticles]);
 
   useEffect(() => {
     if (!newsData) return;
@@ -106,8 +126,35 @@ export const NewsPlayerScreen = ({ articleId }: NewsPlayerScreenProps) => {
     }
   }, []);
 
-  const handleNext = useCallback(() => console.log('다음 기사'), []);
-  const handlePrev = useCallback(() => console.log('이전 기사'), []);
+  const handleNext = useCallback(async () => {
+    if (currentIndex === -1 || currentIndex >= recentArticles.length - 1) {
+      console.log('다음 기사가 없습니다');
+      return;
+    }
+
+    // 오디오 정리
+    await soundRef.current?.unloadAsync();
+    soundRef.current = null;
+
+    // 다음 기사로 이동
+    const nextArticleId = recentArticles[currentIndex + 1];
+    router.replace(`/newsplayer/${nextArticleId}`);
+  }, [currentIndex, recentArticles, router]);
+
+  const handlePrev = useCallback(async () => {
+    if (currentIndex <= 0) {
+      console.log('이전 기사가 없습니다');
+      return;
+    }
+
+    // 오디오 정리
+    await soundRef.current?.unloadAsync();
+    soundRef.current = null;
+
+    // 이전 기사로 이동
+    const prevArticleId = recentArticles[currentIndex - 1];
+    router.replace(`/newsplayer/${prevArticleId}`);
+  }, [currentIndex, recentArticles, router]);
 
   const handleCarModeToggle = useCallback(async () => {
     const newCarMode = !isCarMode;

--- a/components/screens/NewsPlayer/index.ts
+++ b/components/screens/NewsPlayer/index.ts
@@ -4,4 +4,3 @@ export { LyricsDisplay } from './LyricsDisplay'
 export { NewsImagePlaceholder } from './NewsImagePlaceholder'
 export { NewsPlayerHeader } from './NewsPlayerHeader'
 export { NewsPlayerScreen } from './NewsPlayerScreen'
-

--- a/components/screens/SavedNews/SavedNewsList.tsx
+++ b/components/screens/SavedNews/SavedNewsList.tsx
@@ -1,16 +1,13 @@
-import { memo } from 'react'; // 추가: 성능 최적화
+import { memo } from 'react';
 import { ScrollView, Text, View } from 'react-native'
 import { SavedNewsListProps } from '../../../types/screens'
 import { SavedNewsCard } from './SavedNewsCard'
 
-// 개선: memo로 컴포넌트 감싸기
-// 이유: newsList, onNewsPress, onDelete가 변하지 않으면 리렌더링 스킵
 export const SavedNewsList = memo(function SavedNewsList({
   newsList,
   onNewsPress,
   onDelete,
 }: SavedNewsListProps) {
-  // 빈 상태 처리 
   if (newsList.length === 0) {
     return (
       <View className="flex-1 justify-center items-center">
@@ -22,10 +19,9 @@ export const SavedNewsList = memo(function SavedNewsList({
   }
 
   return (
-    <ScrollView 
+    <ScrollView
       className="flex-1 px-4 pt-4"
-      showsVerticalScrollIndicator={false} // 추가: 스크롤바 숨기기
-      // 이유: 더 깔끔한 UI
+      showsVerticalScrollIndicator={false}
     >
       {newsList.map((news) => (
         <SavedNewsCard

--- a/components/screens/SavedNews/SavedNewsList.tsx
+++ b/components/screens/SavedNews/SavedNewsList.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
-import { ScrollView, Text, View } from 'react-native'
-import { SavedNewsListProps } from '../../../types/screens'
-import { SavedNewsCard } from './SavedNewsCard'
+import { ScrollView, Text, View } from 'react-native';
+import { SavedNewsListProps } from '../../../types/screens';
+import { SavedNewsCard } from './SavedNewsCard';
 
 export const SavedNewsList = memo(function SavedNewsList({
   newsList,

--- a/components/screens/SavedNews/index.ts
+++ b/components/screens/SavedNews/index.ts
@@ -1,3 +1,4 @@
 export { SavedNewsCard } from './SavedNewsCard'
 export { SavedNewsList } from './SavedNewsList'
 export { SavedNewsScreen } from './SavedNewsScreen'
+

--- a/components/screens/SavedNews/index.ts
+++ b/components/screens/SavedNews/index.ts
@@ -1,4 +1,3 @@
 export { SavedNewsCard } from './SavedNewsCard'
 export { SavedNewsList } from './SavedNewsList'
 export { SavedNewsScreen } from './SavedNewsScreen'
-

--- a/components/screens/WordBook/WordBookCalendar.tsx
+++ b/components/screens/WordBook/WordBookCalendar.tsx
@@ -60,13 +60,19 @@ export const WordBookCalendar = ({
       const isCurrentMonth = d.getMonth() === currentDate.getMonth()
 
       days.push(
-        <View 
+        <View
           key={key}
           style={{ width: '14.28%' }}
           className="items-center py-3"
         >
           <TouchableOpacity
-            onPress={() => item && onDateSelect(d)}
+            onPress={() => {
+              if (item) {
+                // 타임존 문제 방지: 정오(12:00)로 설정
+                const dateAtNoon = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 12, 0, 0, 0)
+                onDateSelect(dateAtNoon)
+              }
+            }}
             className="items-center"
             activeOpacity={0.7}
           >

--- a/components/screens/WordBook/WordBookScreen.tsx
+++ b/components/screens/WordBook/WordBookScreen.tsx
@@ -11,8 +11,14 @@ import { WordBookChipList } from './WordBookChipList';
 import { WordBookDateDisplay } from './WordBookDateDisplay';
 
 export const WordBookScreen = () => {
-  const [currentDate, setCurrentDate] = useState(new Date())
-  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date())
+  // 타임존 문제 방지: 초기 날짜를 정오(12:00)로 설정
+  const getDateAtNoon = () => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 0, 0, 0)
+  }
+
+  const [currentDate, setCurrentDate] = useState(getDateAtNoon())
+  const [selectedDate, setSelectedDate] = useState<Date | null>(getDateAtNoon())
   const [calendarData, setCalendarData] = useState<WordBookCalendarItem[]>([])
   const [todayWords, setTodayWords] = useState<SavedWord[]>([])
   const [selectedWord, setSelectedWord] = useState<SavedWord | null>(null)
@@ -30,12 +36,15 @@ export const WordBookScreen = () => {
     try {
       setLoading(true)
       setError(null)
-      
+
       const response = await wordbookService.getCalendar(currentDate)
       setCalendarData(response)
-      
-      console.log('캘린더 데이터 로드:', currentDate)
-      
+
+      // 타임존 문제 없이 날짜 출력
+      const year = currentDate.getFullYear()
+      const month = String(currentDate.getMonth() + 1).padStart(2, '0')
+      console.log('캘린더 데이터 로드:', `${year}-${month}`)
+
     } catch (err) {
       setError('캘린더를 불러올 수 없습니다.')
       console.error('캘린더 로드 실패:', err)
@@ -50,9 +59,13 @@ export const WordBookScreen = () => {
     try {
       const response = await wordbookService.getWordsByDate(date)
       setTodayWords(response)
-      
-      console.log('단어 로드:', date)
-      
+
+      // 타임존 문제 없이 날짜 출력
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      console.log('단어 로드:', `${year}-${month}-${day}`)
+
     } catch (error) {
       console.error('단어 로드 실패:', error)
     }

--- a/services/news/newsService.ts
+++ b/services/news/newsService.ts
@@ -20,6 +20,13 @@ export const newsService = {
   // 뉴스 플레이어용 데이터 조회
   async getNewsDetail(articleId: string): Promise<NewsPlayerData> {
     const article = await this.getArticleDetail(articleId)
+
+    // 디버깅: audioUrl 로그
+    console.log('=== 기사 오디오 정보 ===')
+    console.log('articleId:', articleId)
+    console.log('ttsUrl:', article.detail.ttsUrl)
+    console.log('ttsUrl 존재:', !!article.detail.ttsUrl)
+
     return {
       title: article.title,
       imageUrl: article.imageUrl,

--- a/services/wordbook/wordbookService.ts
+++ b/services/wordbook/wordbookService.ts
@@ -56,7 +56,11 @@ export const wordbookService = {
       })
     }
 
-    const dateStr = format(date, 'yyyy-MM-dd')
+    // 타임존 영향 없이 날짜 문자열 생성
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    const dateStr = `${year}-${month}-${day}`
 
     // GET /api/words/date?date=2025-11-05
     const response = await apiClient.get<ApiResponse<{ words: Array<{ wordId: number; word: string }> }>>(

--- a/types/screens.ts
+++ b/types/screens.ts
@@ -106,7 +106,7 @@ export interface SavedWord {
   id: string
   word: string
 //  savedDate: string  // YYYY-MM-DD
-  definition?: string //추가: 단어 뜻 
+  definition?: string //추가: 단어 뜻
   savedAt: string
 }
 


### PR DESCRIPTION
### 📌 PR 템플릿
1. 단어 저장 해당 날짜로 들어가게 수정완료
2. 캘린더 해당 날짜 클릭시 로그에 하루 전 뜨는 현상, 타임존 수정
3. 저장 뉴스 삭제 해결
4. 뉴스 재생화면 기사 앞/뒤 이동 추가 (근데 앞 뒤 기사 Id를 받아올 수 없어 최근 봤던 기사들을 앞 뒤로 이동할 수 있는 기능입니다.)
5. AI토론의 토론하기 탭에 스크롤 기능 추가
6. 토론하기의 card css 수정

## 🪺 Summary
(변경한 내용을 간단히 작성)

## 🌱 Issue Number
- #

## 🙏 To Reviewers
(리뷰어에게 전달하고 싶은 말)
```