### PR TITLE
fix: 뉴스 오디오 수정

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Slot, usePathname } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { ActivityIndicator, View } from "react-native";
+import { AudioProvider } from "../contexts/AudioContext";
 import "../global.css";
 import LoginPage from "./LoginPage";
 
@@ -48,5 +49,9 @@ export default function RootLayout() {
   }
 
   // 인증 여부 확인 후 Slot 렌더링
-  return <Slot />;
+  return (
+    <AudioProvider>
+      <Slot />
+    </AudioProvider>
+  );
 }

--- a/components/screens/Dictionary/DictionaryModal.tsx
+++ b/components/screens/Dictionary/DictionaryModal.tsx
@@ -103,8 +103,8 @@ export function DictionaryModal({
         style={{ backgroundColor: 'rgba(0, 0, 0, 0.7)' }}
         onPress={onClose}
       >
-        <Pressable 
-          className="bg-white rounded-3xl p-6 mx-8 w-full max-w-md"
+        <Pressable
+          className="bg-white rounded-3xl p-6 mx-10 w-full max-w-sm"
           onPress={(e) => e.stopPropagation()}
         >
           <Text className="text-2xl font-bold text-center mb-4">{word}</Text>

--- a/components/screens/Dictionary/DictionarySearchBar.tsx
+++ b/components/screens/Dictionary/DictionarySearchBar.tsx
@@ -102,17 +102,17 @@ export function DictionarySearchBar({
             onChangeText={setSearchText}
             onSubmitEditing={handleSearch}
             returnKeyType="search"
-            className="flex-1 text-base text-gray-800 px-6"
+            className="flex-1 text-gray-800 px-6"
             style={{
-              textAlignVertical: 'center',
-              paddingVertical: 0,
-              height: 56,
+              fontSize: 16,
               lineHeight: 20,
+              paddingTop: 0,
+              paddingBottom: 0,
             }}
           />
 
-          <TouchableOpacity 
-            onPress={onClose} 
+          <TouchableOpacity
+            onPress={onClose}
             className="px-4"
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >

--- a/components/screens/Dictionary/DictionarySearchBar.tsx
+++ b/components/screens/Dictionary/DictionarySearchBar.tsx
@@ -103,6 +103,12 @@ export function DictionarySearchBar({
             onSubmitEditing={handleSearch}
             returnKeyType="search"
             className="flex-1 text-base text-gray-800 px-6"
+            style={{
+              textAlignVertical: 'center',
+              paddingVertical: 0,
+              height: 56,
+              lineHeight: 20,
+            }}
           />
 
           <TouchableOpacity 

--- a/components/screens/Dictionary/WordDefinition.tsx
+++ b/components/screens/Dictionary/WordDefinition.tsx
@@ -24,4 +24,4 @@ export const WordDefinition = (
       ))}
     </View>
   </ScrollView>
-);
+)

--- a/components/screens/Discussion/DiscussionNewsCard.tsx
+++ b/components/screens/Discussion/DiscussionNewsCard.tsx
@@ -20,7 +20,7 @@ export function DiscussionNewsCard({ news, onPress }: DiscussionNewsCardProps) {
         elevation: 4,
         borderRadius: 16,
       }}
-      className="self-center mb-5"
+      className="self-center mb-3"
       activeOpacity={0.7}
     >
       <View

--- a/components/screens/Discussion/DiscussionNewsList.tsx
+++ b/components/screens/Discussion/DiscussionNewsList.tsx
@@ -67,7 +67,7 @@ export function DiscussionNewsList({
       <ScrollView
         className="flex-1"
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 20 }}
+        contentContainerStyle={{ paddingBottom: 0 }}
       >
         {news.length === 0 ? (
           <View className="flex-1 items-center justify-center py-20">

--- a/components/screens/Discussion/DiscussionNewsList.tsx
+++ b/components/screens/Discussion/DiscussionNewsList.tsx
@@ -13,7 +13,7 @@ export function DiscussionNewsList({
 
   const sortOptions = [
     { value: 'latest', label: '최신순' },
-    { value: 'oldest', label: '날짜순' },
+    { value: 'oldest', label: '오래된순' },
   ] as const
 
   const currentLabel = sortOptions.find(opt => opt.value === sortBy)?.label || '최신순'

--- a/components/screens/Discussion/DiscussionRecordList.tsx
+++ b/components/screens/Discussion/DiscussionRecordList.tsx
@@ -64,7 +64,11 @@ export function DiscussionRecordList({
       </View>
 
       {/* 기록 리스트 */}
-      <ScrollView className="flex-1">
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 0 }}
+      >
         {records.length === 0 ? (
           <View className="flex-1 items-center justify-center py-20">
             <Text className="text-gray-400 text-base">토론 기록이 없습니다</Text>

--- a/components/screens/Discussion/DiscussionScreen.tsx
+++ b/components/screens/Discussion/DiscussionScreen.tsx
@@ -138,7 +138,7 @@ export function DiscussionScreen() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-[#F5FCE9]" edges={['bottom', 'left', 'right']}>
+    <SafeAreaView className="flex-1 bg-[#F5FCE9]" edges={['left', 'right']}>
       <TopBar showBackButton={false} />
 
       <DiscussionHeader />

--- a/components/screens/NewsArticle/NewsArticleScreen.tsx
+++ b/components/screens/NewsArticle/NewsArticleScreen.tsx
@@ -198,11 +198,11 @@ export function NewsArticleScreen({ articleId }: NewsArticleScreenProps) {
       {/* 검색 결과 없음 모달 */}
       <Modal
         visible={showSearchErrorModal}
-        title="기사 본문에서 해당 단어를 찾을 수 없습니다."
+        title="해당 단어를 찾을 수 없습니다."
         onConfirm={() => setShowSearchErrorModal(false)}
         onClose={() => setShowSearchErrorModal(false)}
       >
-        <View className="mt-6 mb-[-16px]">
+        <View className="mt-4 mb-[-16px]">
           <TouchableOpacity
             className="bg-[#006716] py-3 rounded-xl"
             onPress={() => setShowSearchErrorModal(false)}

--- a/components/screens/NewsPlayer/NewsPlayerScreen.tsx
+++ b/components/screens/NewsPlayer/NewsPlayerScreen.tsx
@@ -1,4 +1,5 @@
 import { Modal } from '@/components/common';
+import { useAudio } from '@/contexts/AudioContext';
 import { Audio } from 'expo-av';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -21,14 +22,13 @@ interface NewsPlayerScreenProps {
 export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => {
   const router = useRouter();
   const { category } = useLocalSearchParams<{ category?: string }>();
+  const { isPlaying, loadAudio, play, pause } = useAudio();
   const [newsData, setNewsData] = useState<NewsPlayerData | null>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
   const [isCarMode, setIsCarMode] = useState(false);
   const [showDiscussionModal, setShowDiscussionModal] = useState(false);
   const [currentLines, setCurrentLines] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const soundRef = useRef<Audio.Sound | null>(null);
 
   // 최근 본 기사 목록
   const [recentArticles, setRecentArticles] = useState<number[]>([]);
@@ -98,32 +98,12 @@ export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => 
     setCurrentLines([newsData.fullText]);
   }, [newsData]);
 
-  const loadAudio = useCallback(async () => {
-    if (!newsData?.audioUrl) return;
-    try {
-      const { sound } = await Audio.Sound.createAsync(
-        { uri: newsData.audioUrl },
-        { shouldPlay: true }
-      );
-      soundRef.current = sound;
-      sound.setOnPlaybackStatusUpdate((status) => {
-        if (status.isLoaded) {
-          setIsPlaying(status.isPlaying);
-        }
-      });
-    } catch (err) {
-      // 오디오 로드 실패 시 무음 처리
-    }
-  }, [newsData]);
-
+  // 뉴스 데이터가 로드되면 오디오 로드
   useEffect(() => {
-    if (newsData) {
-      loadAudio();
+    if (newsData?.audioUrl) {
+      loadAudio(newsData.audioUrl, articleId);
     }
-    return () => {
-      soundRef.current?.unloadAsync();
-    };
-  }, [newsData, loadAudio]);
+  }, [newsData, articleId, loadAudio]);
 
   const handleBack = useCallback(() => {
     if (from === 'savednews') {
@@ -141,35 +121,19 @@ export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => 
   }, [router, from]);
 
   const handlePlay = useCallback(async () => {
-    if (!soundRef.current) return;
-    try {
-      await soundRef.current.playAsync();
-      setIsPlaying(true);
-    } catch (err) {
-      // 재생 실패 시 무시
-    }
-  }, []);
+    await play();
+  }, [play]);
 
   const handlePause = useCallback(async () => {
-    if (!soundRef.current) return;
-    try {
-      await soundRef.current.pauseAsync();
-      setIsPlaying(false);
-    } catch (err) {
-      // 일시정지 실패 시 무시
-    }
-  }, []);
+    await pause();
+  }, [pause]);
 
   const handleNext = useCallback(async () => {
     if (currentIndex === -1 || currentIndex >= recentArticles.length - 1) {
       return;
     }
 
-    // 오디오 정리
-    await soundRef.current?.unloadAsync();
-    soundRef.current = null;
-
-    // 다음 기사로 이동
+    // 다음 기사로 이동 (오디오는 Context에서 자동으로 관리)
     const nextArticleId = recentArticles[currentIndex + 1];
     router.replace(`/newsplayer/${nextArticleId}`);
   }, [currentIndex, recentArticles, router]);
@@ -179,11 +143,7 @@ export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => 
       return;
     }
 
-    // 오디오 정리
-    await soundRef.current?.unloadAsync();
-    soundRef.current = null;
-
-    // 이전 기사로 이동
+    // 이전 기사로 이동 (오디오는 Context에서 자동으로 관리)
     const prevArticleId = recentArticles[currentIndex - 1];
     router.replace(`/newsplayer/${prevArticleId}`);
   }, [currentIndex, recentArticles, router]);

--- a/components/screens/NewsPlayer/NewsPlayerScreen.tsx
+++ b/components/screens/NewsPlayer/NewsPlayerScreen.tsx
@@ -73,25 +73,6 @@ export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => 
     fetchRecentArticles();
   }, [fetchNewsData, fetchRecentArticles]);
 
-  // 초기 오디오 모드 설정 (무음 모드에서도 재생)
-  useEffect(() => {
-    const setupAudioMode = async () => {
-      try {
-        await Audio.setAudioModeAsync({
-          allowsRecordingIOS: false,
-          playsInSilentModeIOS: true,
-          staysActiveInBackground: false,
-          interruptionModeIOS: 0,
-          shouldDuckAndroid: false,
-          playThroughEarpieceAndroid: false,
-        });
-      } catch {
-        // 오디오 모드 설정 실패 시 무시
-      }
-    };
-    setupAudioMode();
-  }, []);
-
   useEffect(() => {
     if (!newsData) return;
     // 전체 텍스트를 currentLines에 배열로 설정 (LyricsDisplay에서 join으로 합침)
@@ -155,9 +136,9 @@ export const NewsPlayerScreen = ({ articleId, from }: NewsPlayerScreenProps) => 
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: false,
         playsInSilentModeIOS: true,
-        staysActiveInBackground: newCarMode,
+        staysActiveInBackground: newCarMode, // ON: 백그라운드 허용, OFF: 백그라운드 안됨
         interruptionModeIOS: newCarMode ? 1 : 0,
-        shouldDuckAndroid: newCarMode,
+        shouldDuckAndroid: false, // 다른 앱 오디오와 겹치면 이 앱 오디오 끔
         playThroughEarpieceAndroid: false,
       });
     } catch {

--- a/contexts/AudioContext.tsx
+++ b/contexts/AudioContext.tsx
@@ -1,0 +1,134 @@
+import { Audio } from 'expo-av'
+import { usePathname } from 'expo-router'
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+
+interface AudioContextType {
+  sound: Audio.Sound | null
+  isPlaying: boolean
+  currentArticleId: string | null
+  loadAudio: (audioUrl: string, articleId: string) => Promise<void>
+  play: () => Promise<void>
+  pause: () => Promise<void>
+  unload: () => Promise<void>
+}
+
+const AudioContext = createContext<AudioContextType | undefined>(undefined)
+
+export const AudioProvider = ({ children }: { children: React.ReactNode }) => {
+  const pathname = usePathname()
+  const soundRef = useRef<Audio.Sound | null>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentArticleId, setCurrentArticleId] = useState<string | null>(null)
+
+  // 초기 오디오 모드 설정
+  useEffect(() => {
+    const setupAudioMode = async () => {
+      try {
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          playsInSilentModeIOS: true,
+          staysActiveInBackground: false,
+          interruptionModeIOS: 0,
+          shouldDuckAndroid: false,
+          playThroughEarpieceAndroid: false,
+        })
+      } catch {
+        // 오디오 모드 설정 실패 시 무시
+      }
+    }
+    setupAudioMode()
+  }, [])
+
+  const loadAudio = useCallback(async (audioUrl: string, articleId: string) => {
+    try {
+      // 기존 오디오가 같은 기사면 유지
+      if (currentArticleId === articleId && soundRef.current) {
+        return
+      }
+
+      // 다른 기사면 기존 오디오 정리
+      if (soundRef.current) {
+        await soundRef.current.unloadAsync()
+        soundRef.current = null
+      }
+
+      const { sound } = await Audio.Sound.createAsync(
+        { uri: audioUrl },
+        { shouldPlay: true }
+      )
+
+      soundRef.current = sound
+      setCurrentArticleId(articleId)
+
+      sound.setOnPlaybackStatusUpdate((status) => {
+        if (status.isLoaded) {
+          setIsPlaying(status.isPlaying)
+        }
+      })
+    } catch (err) {
+      console.error('오디오 로드 실패:', err);
+    }
+  }, [currentArticleId])
+
+  const play = useCallback(async () => {
+    if (!soundRef.current) return
+    try {
+      await soundRef.current.playAsync()
+      setIsPlaying(true)
+    } catch (err) {
+      console.error('재생 실패:', err)
+    }
+  }, [])
+
+  const pause = useCallback(async () => {
+    if (!soundRef.current) return
+    try {
+      await soundRef.current.pauseAsync()
+      setIsPlaying(false)
+    } catch (err) {
+      console.error('일시정지 실패:', err)
+    }
+  }, [])
+
+  const unload = useCallback(async () => {
+    if (soundRef.current) {
+      await soundRef.current.unloadAsync()
+      soundRef.current = null
+      setCurrentArticleId(null)
+      setIsPlaying(false)
+    }
+  }, [])
+
+  // 뉴스 재생/기사 화면이 아니면 오디오 정리
+  useEffect(() => {
+    const isNewsScreen = pathname.includes('/newsplayer/') || pathname.includes('/newsarticle/')
+
+    if (!isNewsScreen && soundRef.current) {
+      unload()
+    }
+  }, [pathname, unload])
+
+  return (
+    <AudioContext.Provider
+      value={{
+        sound: soundRef.current,
+        isPlaying,
+        currentArticleId,
+        loadAudio,
+        play,
+        pause,
+        unload,
+      }}
+    >
+      {children}
+    </AudioContext.Provider>
+  )
+}
+
+export const useAudio = () => {
+  const context = useContext(AudioContext)
+  if (!context) {
+    throw new Error('useAudio must be used within AudioProvider')
+  }
+  return context
+}


### PR DESCRIPTION
### 📌 PR 템플릿

오디오 수정

## 🪺 Summary

1. 전역으로 오디오 관리를 위해, contexts/AudioContext.tsx를 생성했습니다.
-> 이제 뉴즈 재생, 기사 화면에서는 오디오 유지됩니다.

2. app/_layout.tsx를 수정했습니다. 앱 전체를 AudioProvider로 감싸서 모든 화면에서 오디오 상태를 공유하도록 했습니다.

3. Car mode = on 일 경우는 백그라운드 허용, 오디오 겹칠 시 끄기
Car mode = off 일 경우는 백그라운드 자체가 불가능합니다.

4. AudioContext에 초기 오디오 설정이 있어서 중복 코드 삭제하였습니다. 

5. AI토론 뉴스카드와 네비바 사이 공백 삭제

6. 단어 검색 시 모달이 화면에 꽉 차있는 현상 수정하였습니다, 본문에 있지 않은 단어 검색 시 2줄로 가독성이 조금 떨어져 수정하였습니다.
 
7. 뉴스 기사 화면에서 단어 검색시 아래로 쳐지는 이슈 해결하였습니다.

## 🌱 Issue Number


## 🙏 To Reviewers
(리뷰어에게 전달하고 싶은 말)
```